### PR TITLE
Do not print message template values to prevent duplication in console logs

### DIFF
--- a/Decos.Diagnostics.AspNetCore/Decos.Diagnostics.AspNetCore.csproj
+++ b/Decos.Diagnostics.AspNetCore/Decos.Diagnostics.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.2.1-alpha2</Version>
+    <Version>1.2.1-alpha3</Version>
     <Authors>Laura Verdoes</Authors>
     <Company>Decos Information Solutions</Company>
     <Description>Provides extension methods for registering the Decos.Diagnostics TraceSource implementation as services with the Microsoft.Extensions.DependencyInjection framework.</Description>

--- a/Decos.Diagnostics.AspNetCore/MicrosoftExtensionsLogging/DecosDiagnosticsLogger.cs
+++ b/Decos.Diagnostics.AspNetCore/MicrosoftExtensionsLogging/DecosDiagnosticsLogger.cs
@@ -86,10 +86,7 @@ namespace Decos.Diagnostics.AspNetCore.MicrosoftExtensionsLogging
                 if (formattedLogValues.Count <= 1)
                     return null;
 
-                // FormattedLogValues always inserts the original format at the end.
-                return formattedLogValues
-                    .Take(formattedLogValues.Count - 1)
-                    .ToDictionary(x => x.Key, x => x.Value);
+                return new FormattedLogValues(formattedLogValues);
             }
 
             return state;

--- a/Decos.Diagnostics/Decos.Diagnostics.csproj
+++ b/Decos.Diagnostics/Decos.Diagnostics.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.2.0-alpha2</Version>
+    <Version>1.2.0-alpha3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Laura Verdoes</Authors>
     <Company>Decos Information Solutions</Company>

--- a/Decos.Diagnostics/FormattedLogValues.cs
+++ b/Decos.Diagnostics/FormattedLogValues.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Decos.Diagnostics
+{
+    /// <summary>
+    /// Represents a collection of values passed to logged message templates in ASP.NET Core logging.
+    /// </summary>
+    public class FormattedLogValues : Dictionary<string, object>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FormattedLogValues"/> class with the
+        /// specified formatted log values.
+        /// </summary>
+        /// <param name="items">The internal FormattedLogValues object.</param>
+        public FormattedLogValues(IReadOnlyList<KeyValuePair<string, object>> items)
+        {
+            if (items.Count <= 1)
+            {
+                return;
+            }
+
+            // FormattedLogValues always inserts the original format at the end.
+            foreach (var keyValuePair in items.Take(items.Count - 1))
+                Add(keyValuePair.Key, keyValuePair.Value);
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return string.Join(", ", this.Select(x => $"{x.Key}: {x.Value}"));
+        }
+    }
+}

--- a/Decos.Diagnostics/LogData.cs
+++ b/Decos.Diagnostics/LogData.cs
@@ -55,9 +55,13 @@ namespace Decos.Diagnostics
             {
                 switch (data)
                 {
+                    // FormattedLogValues is used for message templates in ASP.NET Core logging and
+                    // won't add any value when printed over the message itself
+                    case FormattedLogValues _:
                     case null:
                         return null;
 
+                    // We will want to show any other type of dictionary, though
                     case IDictionary dictionary:
                         return string.Join(", ", dictionary.Keys.OfType<object>().Select(key => $"{key}: {dictionary[key]}"));
 


### PR DESCRIPTION
Values should still be available and serialized though