### PR TITLE
Error handling

### DIFF
--- a/Decos.Diagnostics.AspNetCore.Tests/DecosDiagnosticsServiceCollectionExtensionsTests.cs
+++ b/Decos.Diagnostics.AspNetCore.Tests/DecosDiagnosticsServiceCollectionExtensionsTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using Decos.Diagnostics.Trace.Tests;
+using Decos.Diagnostics.Trace.Tests.Mocks;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Decos.Diagnostics.Trace.Tests/Mocks/DelayAsyncTraceListener.cs
+++ b/Decos.Diagnostics.Trace.Tests/Mocks/DelayAsyncTraceListener.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Decos.Diagnostics.Trace.Tests
+namespace Decos.Diagnostics.Trace.Tests.Mocks
 {
     public class DelayAsyncTraceListener : AsyncTraceListener
     {

--- a/Decos.Diagnostics.Trace.Tests/Mocks/NullTraceListener.cs
+++ b/Decos.Diagnostics.Trace.Tests/Mocks/NullTraceListener.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Decos.Diagnostics.Trace.Tests
+namespace Decos.Diagnostics.Trace.Tests.Mocks
 {
     /// <summary>
     /// Represents a trace listener that does nothing.

--- a/Decos.Diagnostics.Trace.Tests/Mocks/ThrowingAsyncTraceListener.cs
+++ b/Decos.Diagnostics.Trace.Tests/Mocks/ThrowingAsyncTraceListener.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Decos.Diagnostics.Trace.Tests.Mocks
+{
+    internal class ThrowingAsyncTraceListener : AsyncTraceListener
+    {
+        public override Task TraceAsync(LogEntry logEntry, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Decos.Diagnostics.Trace.Tests/TraceSourceLogFactoryBuilderTests.cs
+++ b/Decos.Diagnostics.Trace.Tests/TraceSourceLogFactoryBuilderTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Decos.Diagnostics.Trace.Tests.Mocks;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Decos.Diagnostics.Trace.Tests

--- a/Decos.Diagnostics.Trace.Tests/TraceSourceLogFactoryTests.cs
+++ b/Decos.Diagnostics.Trace.Tests/TraceSourceLogFactoryTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Decos.Diagnostics.Trace.Tests.Mocks;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Decos.Diagnostics.Trace.Tests

--- a/Decos.Diagnostics.Trace/AsyncTraceListener.cs
+++ b/Decos.Diagnostics.Trace/AsyncTraceListener.cs
@@ -67,7 +67,18 @@ namespace Decos.Diagnostics.Trace
                 while (RequestQueue.TryDequeue(out var logEntry))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    await TraceAsync(logEntry, cancellationToken);
+                    try
+                    {
+                        await TraceAsync(logEntry, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Unhandled exception in {GetType().Name}.TraceAsync: {ex}.\n\nLog entry: {logEntry}");
+                    }
                 }
 
                 if (RequestQueue.Count == 0 && shutdownToken.IsCancellationRequested)

--- a/Decos.Diagnostics.Trace/Decos.Diagnostics.Trace.csproj
+++ b/Decos.Diagnostics.Trace/Decos.Diagnostics.Trace.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.5</Version>
+    <Version>1.3.6</Version>
     <Authors>Laura Verdoes</Authors>
     <Company>Decos Information Solutions</Company>
     <Product>Decos.Diagnostics.Trace</Product>
     <Description>Provides a System.Diagnostics.TraceSource implementation for the Decos.Diagnostics abstractions.</Description>
     <DocumentationFile>C:\Decos\Git\Decos.Diagnostics\Decos.Diagnostics.Trace\Decos.Diagnostics.Trace.xml</DocumentationFile>
-    <PackageReleaseNotes>Fixed a potential performance issue with async listeners.</PackageReleaseNotes>
+    <PackageReleaseNotes>Improved error handling with async trace listeners.</PackageReleaseNotes>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Decos.Diagnostics.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/Decos.Diagnostics/LogEntry.cs
+++ b/Decos.Diagnostics/LogEntry.cs
@@ -94,5 +94,12 @@ namespace Decos.Diagnostics
 
             return string.Empty;
         }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"{Source} {Level}: {Message}";
+        }
     }
 }

--- a/TestSendCore/Program.cs
+++ b/TestSendCore/Program.cs
@@ -86,7 +86,7 @@ namespace TestSendCore
                 options.SetMinimumLogLevel(LogLevel.Debug);
                 options.AddConsole();
 
-                var logstashAddress = Environment.GetEnvironmentVariable("LOGSTASH_ADDRESS");
+                var logstashAddress = "http://127.0.0.1:9090/"; Environment.GetEnvironmentVariable("LOGSTASH_ADDRESS");
                 if (!string.IsNullOrEmpty(logstashAddress))
                     options.AddLogstash(logstashAddress);
 


### PR DESCRIPTION
Should solve logs disappearing forever when an async trace listener (e.g. Logstash) throws an exception.

Faulted logs are written to the console, but retry logic should be added too. This will be done separately.