### PR TITLE
When testing in the debugger, it breaks on a NullReferenceException if Decos.Diagnos…

### DIFF
--- a/Decos.Diagnostics.Trace.Tests/AsyncTraceListenerTests.cs
+++ b/Decos.Diagnostics.Trace.Tests/AsyncTraceListenerTests.cs
@@ -87,3 +87,30 @@ namespace Decos.Diagnostics.Trace.Tests
         }
     }
 }
+
+[TestClass]
+public class NoNamespaceTraceTest
+{
+  private const int Delay = 100;
+  private const int EventCount = 10;
+
+  [TestMethod]
+  public async Task AsyncTraceListenerDoesNotThrowWhenCalledWithoutNamespace()
+  {
+    var listener = new DelayAsyncTraceListener(Delay);
+
+    for (int i = 0; i < EventCount; i++)
+    {
+      listener.WriteLine(i);
+    }
+
+    var cancellation = new CancellationTokenSource(Delay);
+    try
+    {
+      await listener.ProcessQueueAsync(CancellationToken.None, cancellation.Token);
+    }
+    catch (OperationCanceledException) { }
+
+    Assert.AreNotEqual(0, listener.QueueCount);
+  }
+}

--- a/Decos.Diagnostics.Trace/TraceListenerBase.cs
+++ b/Decos.Diagnostics.Trace/TraceListenerBase.cs
@@ -632,7 +632,7 @@ namespace Decos.Diagnostics.Trace
                     foreach (var frame in stackFrames) {
                         var frameReflectedType = frame.GetMethod().ReflectedType;
                         var namespaceName = frameReflectedType.Namespace;
-                        if (!namespaceName.StartsWith("System.Diagnostics") && !namespaceName.StartsWith("Decos.Diagnostics")) {
+                        if (namespaceName != null && !namespaceName.StartsWith("System.Diagnostics") && !namespaceName.StartsWith("Decos.Diagnostics")) {
                             return frameReflectedType.ToString();
                         }
                     }


### PR DESCRIPTION
…tics is called from a class not in a namespace. 

This resolves that NullReferenceException.
**Note** that this is **not** an issue in production, but wasted about an hour of my time while debugging something unrelated. 